### PR TITLE
Add Harbor registry support for image publishing

### DIFF
--- a/.github/workflows/publish-harbor.yml
+++ b/.github/workflows/publish-harbor.yml
@@ -1,0 +1,59 @@
+name: Build & publish to Harbor
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "Dockerfile"
+      - "package.json"
+      - "package-lock.json"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  REGISTRY: harbor.${{ secrets.SECRET_DOMAIN }}
+  IMAGE_NAME: harbor.${{ secrets.SECRET_DOMAIN }}/library/software-planning-mcp
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.HARBOR_ROBOT_USER }}
+          password: ${{ secrets.HARBOR_ROBOT_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: echo ${{ steps.build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Install pnpm in production image
-RUN npm install -g pnpm
+# Install pnpm and supergateway in production image
+RUN npm install -g pnpm supergateway
 
 # Copy package files and install production dependencies only
 COPY package*.json ./

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ GITHUB_USERNAME ?= erauner
 SECRET_DOMAIN ?= erauner.dev
 REGISTRY ?= ghcr.io
 HARBOR_REGISTRY = harbor.$(SECRET_DOMAIN)
-HARBOR_USERNAME ?= robot$$library+deployer
+HARBOR_USERNAME ?= robot$$robot_account
 HARBOR_PASSWORD ?=
 
 # Image naming

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -92,6 +92,19 @@ tasks:
       - rm -rf .planning
       - echo "Clean complete"
 
+  # Container operations
+  push-harbor:
+    desc: "Build & push image to Harbor (local)"
+    cmds:
+      - make docker-push-harbor
+      - echo "Image pushed to Harbor registry"
+
+  push-ghcr:
+    desc: "Build & push image to GHCR (local)"
+    cmds:
+      - make docker-push REGISTRY=ghcr.io
+      - echo "Image pushed to GHCR registry"
+
   # Git operations
   pre-commit:
     desc: "Run pre-commit hooks manually"

--- a/docs/k8s-testing.md
+++ b/docs/k8s-testing.md
@@ -1,0 +1,204 @@
+# Kubernetes Testing Guide for MCP Software Planning
+
+This guide explains how to test the MCP Software Planning server deployed in Kubernetes without relying on external URLs.
+
+## Prerequisites
+
+- `kubectl` configured with access to your cluster
+- `jq` installed for JSON parsing (optional but recommended)
+- Access to the `devops` namespace (or adjust `K8S_NAMESPACE` env var)
+
+## Quick Start
+
+```bash
+# Run quick smoke test
+make k8s-quick-test
+
+# Run comprehensive tests
+make k8s-test
+
+# Run interactive demo
+make k8s-demo
+```
+
+## Available Test Scripts
+
+### 1. Quick Test (`k8s-quick-test.sh`)
+Fast smoke test that verifies basic functionality:
+- Health endpoint
+- Supergateway process
+- Redis connectivity
+- MCP server response
+- External access (optional)
+
+```bash
+./scripts/k8s-quick-test.sh
+```
+
+### 2. Comprehensive Test (`k8s-test.sh`)
+Full test suite including:
+- Deployment status
+- Health checks
+- Supergateway verification
+- Redis connection
+- Direct MCP server testing
+
+```bash
+./scripts/k8s-test.sh
+```
+
+### 3. Tools Test (`k8s-tools-test.sh`)
+Tests all MCP tools functionality:
+- Initialize protocol
+- List available tools
+- Start planning
+- Save plans
+- Add/get todos
+- Session isolation
+
+```bash
+./scripts/k8s-tools-test.sh
+```
+
+### 4. Debug Script (`k8s-debug.sh`)
+Detailed debugging information:
+- Deployment details
+- Pod events
+- Service endpoints
+- HTTPRoute configuration
+- Process listing
+- Environment variables
+- Network connectivity
+- Recent logs
+
+```bash
+./scripts/k8s-debug.sh
+```
+
+### 5. Example Usage (`k8s-example-usage.sh`)
+Interactive client and demo scenarios:
+
+```bash
+# Run demo scenario
+./scripts/k8s-example-usage.sh demo
+
+# Start interactive mode
+./scripts/k8s-example-usage.sh interactive
+```
+
+## Testing Without External URLs
+
+All tests work by using `kubectl exec` to run commands inside the pod. This approach:
+- Doesn't require external network access
+- Tests the actual deployed container
+- Verifies internal connectivity
+- Works even if ingress/HTTPRoute is misconfigured
+
+### Example: Direct MCP Testing
+
+```bash
+# Get pod name
+POD=$(kubectl get pods -n devops -l app=mcp-software-planning -o jsonpath='{.items[0].metadata.name}')
+
+# Test MCP server directly via stdio
+kubectl exec -n devops $POD -- sh -c 'echo '\''{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'\'' | node /app/build/index.js'
+```
+
+## Environment Variables
+
+All scripts support these environment variables:
+
+- `K8S_NAMESPACE` - Kubernetes namespace (default: `devops`)
+- `APP_LABEL` - Pod selector label (default: `app=mcp-software-planning`)
+- `TEST_USER` - User ID for testing (default: `k8s-test-user`)
+- `TEST_SESSION` - Session ID for testing (default: `k8s-test-session`)
+
+Example usage:
+```bash
+K8S_NAMESPACE=my-namespace TEST_USER=alice ./scripts/k8s-tools-test.sh
+```
+
+## Makefile Targets
+
+```bash
+make k8s-quick-test    # Quick smoke test
+make k8s-test          # Comprehensive test suite
+make k8s-test-tools    # Test all MCP tools
+make k8s-debug         # Show debug information
+make k8s-logs          # Follow pod logs
+make k8s-status        # Quick status check
+make k8s-demo          # Run demo scenario
+make k8s-interactive   # Start interactive client
+```
+
+## Understanding Test Results
+
+### Successful Test Output
+```
+🚀 Quick K8s MCP Test
+====================
+Pod: mcp-software-planning-xxx
+
+1. Health check: ✅ PASS
+2. Supergateway: ✅ Running
+3. Redis connection: ✅ Configured
+4. MCP server: ✅ Responding
+5. External access: ✅ Available
+```
+
+### Common Issues
+
+1. **"Terminated" messages**: Normal behavior when using `timeout` command
+2. **"command terminated with exit code 143"**: Expected when timeout expires
+3. **External access fails**: Check HTTPRoute and ingress configuration
+4. **Redis connection fails**: Verify Redis service is running and accessible
+
+## Debugging Failed Tests
+
+1. Check pod status:
+   ```bash
+   kubectl get pods -n devops -l app=mcp-software-planning
+   ```
+
+2. View recent logs:
+   ```bash
+   make k8s-logs
+   ```
+
+3. Run debug script:
+   ```bash
+   make k8s-debug
+   ```
+
+4. Execute shell in pod:
+   ```bash
+   kubectl exec -it -n devops <pod-name> -- sh
+   ```
+
+## Architecture Notes
+
+The deployment uses:
+- **Supergateway**: HTTP/2 bridge for stdio MCP servers
+- **Stateless mode**: Each request spawns fresh process
+- **Redis backend**: All state stored in Redis
+- **StreamableHttp transport**: Requires proper Accept headers
+
+## CI/CD Integration
+
+These scripts can be integrated into CI/CD pipelines:
+
+```yaml
+# Example GitHub Actions step
+- name: Test K8s deployment
+  run: |
+    ./scripts/k8s-quick-test.sh
+    ./scripts/k8s-tools-test.sh
+```
+
+## Contributing
+
+When adding new tests:
+1. Create script in `scripts/` directory
+2. Make it executable: `chmod +x scripts/your-script.sh`
+3. Add Makefile target for easy access
+4. Document usage in this guide

--- a/scripts/k8s-debug.sh
+++ b/scripts/k8s-debug.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Debug script for K8s MCP deployment
+# Provides detailed debugging information
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Configuration
+NAMESPACE="${K8S_NAMESPACE:-devops}"
+APP_LABEL="${APP_LABEL:-app=mcp-software-planning}"
+
+# Helper functions
+section() {
+    echo ""
+    echo -e "${CYAN}=== $1 ===${NC}"
+}
+
+get_pod_name() {
+    kubectl get pods -n "$NAMESPACE" -l "$APP_LABEL" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# Debug functions
+debug_deployment() {
+    section "Deployment Status"
+    kubectl get deployment -n "$NAMESPACE" -l "$APP_LABEL" -o wide
+
+    section "Deployment Details"
+    kubectl describe deployment -n "$NAMESPACE" -l "$APP_LABEL" | grep -A10 "Containers:" || true
+}
+
+debug_pods() {
+    section "Pod Status"
+    kubectl get pods -n "$NAMESPACE" -l "$APP_LABEL" -o wide
+
+    POD=$(get_pod_name)
+    if [ -n "$POD" ]; then
+        section "Pod Events"
+        kubectl describe pod -n "$NAMESPACE" "$POD" | grep -A20 "Events:" || true
+    fi
+}
+
+debug_service() {
+    section "Service Status"
+    kubectl get svc -n "$NAMESPACE" -l "$APP_LABEL" -o wide
+
+    section "Service Endpoints"
+    kubectl get endpoints -n "$NAMESPACE" -l "$APP_LABEL"
+}
+
+debug_httproute() {
+    section "HTTPRoute Configuration"
+    kubectl get httproute -n "$NAMESPACE" | grep -i planning || echo "No HTTPRoute found"
+
+    # Get HTTPRoute details if exists
+    local route=$(kubectl get httproute -n "$NAMESPACE" -o name | grep -i planning | head -1)
+    if [ -n "$route" ]; then
+        kubectl get "$route" -n "$NAMESPACE" -o yaml | grep -E "(hostnames|parentRefs|backendRefs|port)" || true
+    fi
+}
+
+debug_logs() {
+    section "Recent Logs"
+    POD=$(get_pod_name)
+    if [ -n "$POD" ]; then
+        kubectl logs -n "$NAMESPACE" "$POD" --tail=50
+    else
+        echo "No pod found"
+    fi
+}
+
+debug_processes() {
+    section "Running Processes"
+    POD=$(get_pod_name)
+    if [ -n "$POD" ]; then
+        kubectl exec -n "$NAMESPACE" "$POD" -- ps aux || echo "ps command not available"
+    fi
+}
+
+debug_environment() {
+    section "Environment Variables"
+    POD=$(get_pod_name)
+    if [ -n "$POD" ]; then
+        kubectl exec -n "$NAMESPACE" "$POD" -- env | grep -E "(REDIS|STORAGE|NODE|MCP)" | sort || true
+    fi
+}
+
+debug_network() {
+    section "Network Connectivity Tests"
+    POD=$(get_pod_name)
+    if [ -n "$POD" ]; then
+        echo "Testing localhost:4626..."
+        kubectl exec -n "$NAMESPACE" "$POD" -- wget -qO- http://localhost:4626/health 2>&1 || echo "Failed"
+
+        echo ""
+        echo "Testing Redis connectivity..."
+        kubectl exec -n "$NAMESPACE" "$POD" -- sh -c 'echo "PING" | nc -w 1 ${REDIS_URL#redis://} 2>/dev/null || echo "nc not available or connection failed"'
+    fi
+}
+
+debug_supergateway() {
+    section "Supergateway Status"
+    POD=$(get_pod_name)
+    if [ -n "$POD" ]; then
+        # Check if supergateway is running
+        local sg_pid=$(kubectl exec -n "$NAMESPACE" "$POD" -- pgrep -f supergateway 2>/dev/null || echo "")
+        if [ -n "$sg_pid" ]; then
+            echo "Supergateway PID: $sg_pid"
+
+            # Check listening ports
+            echo ""
+            echo "Listening ports:"
+            kubectl exec -n "$NAMESPACE" "$POD" -- netstat -tlnp 2>/dev/null | grep -E "(4626|LISTEN)" || \
+                kubectl exec -n "$NAMESPACE" "$POD" -- ss -tlnp 2>/dev/null | grep -E "(4626|LISTEN)" || \
+                echo "netstat/ss not available"
+        else
+            echo "Supergateway not running"
+        fi
+    fi
+}
+
+# Main execution
+main() {
+    echo -e "${BLUE}🔍 MCP Software Planning K8s Debug Report${NC}"
+    echo "=========================================="
+    echo "Timestamp: $(date)"
+    echo "Namespace: $NAMESPACE"
+    echo "App Label: $APP_LABEL"
+
+    debug_deployment
+    debug_pods
+    debug_service
+    debug_httproute
+    debug_processes
+    debug_environment
+    debug_network
+    debug_supergateway
+    debug_logs
+
+    section "Debug Complete"
+    echo "Use 'kubectl logs -f -n $NAMESPACE -l $APP_LABEL' to follow logs"
+    echo "Use 'kubectl exec -it -n $NAMESPACE <pod-name> -- sh' for shell access"
+}
+
+# Run main function
+main "$@"

--- a/scripts/k8s-example-usage.sh
+++ b/scripts/k8s-example-usage.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# Example usage of MCP Software Planning server in K8s
+# Shows how to interact with the server using kubectl exec
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+NAMESPACE="${K8S_NAMESPACE:-devops}"
+APP_LABEL="${APP_LABEL:-app=mcp-software-planning}"
+USER_ID="${USER_ID:-demo-user}"
+SESSION_ID="${SESSION_ID:-demo-session}"
+
+# Get pod name
+get_pod() {
+    kubectl get pods -n "$NAMESPACE" -l "$APP_LABEL" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# Execute MCP request
+mcp_request() {
+    local method="$1"
+    local params="$2"
+    local id="${3:-1}"
+    local pod=$(get_pod)
+
+    local request='{"jsonrpc":"2.0","method":"'$method'","params":'$params',"id":'$id'}'
+
+    kubectl exec -n "$NAMESPACE" "$pod" -- sh -c "echo '$request' | timeout 10 node /app/build/index.js 2>/dev/null" | jq '.' 2>/dev/null || echo "Request failed"
+}
+
+# Tool wrapper functions
+initialize() {
+    echo -e "${BLUE}Initializing MCP connection...${NC}"
+    mcp_request "initialize" '{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"clientInfo":{"name":"k8s-demo","version":"1.0"}}'
+}
+
+list_tools() {
+    echo -e "${BLUE}Listing available tools...${NC}"
+    mcp_request "tools/list" '{}'
+}
+
+start_planning() {
+    local task="$1"
+    echo -e "${BLUE}Starting planning: $task${NC}"
+    mcp_request "tools/call" '{"name":"start_planning","arguments":{"task":"'"$task"'","userId":"'"$USER_ID"'","sessionId":"'"$SESSION_ID"'"}}'
+}
+
+save_plan() {
+    local plan="$1"
+    echo -e "${BLUE}Saving plan...${NC}"
+    mcp_request "tools/call" '{"name":"save_plan","arguments":{"plan":"'"$plan"'","userId":"'"$USER_ID"'","sessionId":"'"$SESSION_ID"'"}}'
+}
+
+add_todo() {
+    local description="$1"
+    echo -e "${BLUE}Adding todo: $description${NC}"
+    mcp_request "tools/call" '{"name":"add_todo","arguments":{"description":"'"$description"'","userId":"'"$USER_ID"'","sessionId":"'"$SESSION_ID"'"}}'
+}
+
+get_todos() {
+    echo -e "${BLUE}Getting todos...${NC}"
+    mcp_request "tools/call" '{"name":"get_todos","arguments":{"userId":"'"$USER_ID"'","sessionId":"'"$SESSION_ID"'"}}'
+}
+
+update_todo_status() {
+    local todo_id="$1"
+    local is_complete="$2"
+    echo -e "${BLUE}Updating todo $todo_id to complete=$is_complete...${NC}"
+    mcp_request "tools/call" '{"name":"update_todo_status","arguments":{"todoId":"'"$todo_id"'","isComplete":'$is_complete',"userId":"'"$USER_ID"'","sessionId":"'"$SESSION_ID"'"}}'
+}
+
+# Demo scenario
+demo() {
+    echo -e "${GREEN}🎯 MCP Software Planning Demo${NC}"
+    echo "=============================="
+    echo "User: $USER_ID"
+    echo "Session: $SESSION_ID"
+    echo ""
+
+    # Initialize
+    initialize
+    echo ""
+
+    # Start planning
+    start_planning "Implement user authentication system"
+    echo ""
+
+    # Save plan
+    save_plan "Build a secure authentication system with JWT tokens and OAuth2 support"
+    echo ""
+
+    # Add todos
+    add_todo "Research authentication best practices"
+    add_todo "Design database schema for users"
+    add_todo "Implement JWT token generation"
+    add_todo "Add OAuth2 provider integration"
+    add_todo "Write unit tests"
+    echo ""
+
+    # Get todos
+    echo -e "${YELLOW}Current todos:${NC}"
+    get_todos | jq -r '.result.content[0].text' 2>/dev/null || echo "Failed to get todos"
+    echo ""
+
+    # Get todos to find IDs
+    echo -e "${YELLOW}Getting todo IDs...${NC}"
+    TODOS=$(get_todos)
+
+    # Extract first todo ID (this is a simplified extraction)
+    # In a real script, you'd parse the JSON properly
+    echo "Note: Todo status updates require specific todo IDs from the previous response"
+    echo ""
+
+    # Get updated todos
+    echo -e "${YELLOW}Updated todos:${NC}"
+    get_todos | jq -r '.result.content[0].text' 2>/dev/null || echo "Failed to get todos"
+
+    echo ""
+    echo -e "${GREEN}✅ Demo complete!${NC}"
+}
+
+# Interactive mode
+interactive() {
+    echo -e "${GREEN}🎮 Interactive MCP Client${NC}"
+    echo "========================="
+    echo "Commands:"
+    echo "  init          - Initialize connection"
+    echo "  tools         - List available tools"
+    echo "  plan <task>   - Start planning a task"
+    echo "  save <plan>   - Save plan description"
+    echo "  todo <desc>   - Add a todo item"
+    echo "  list          - List todos"
+    echo "  done <index>  - Mark todo as completed"
+    echo  " demo          - Run demo scenario"
+    echo "  quit          - Exit"
+    echo ""
+
+    while true; do
+        echo -n "> "
+        read -r cmd args
+
+        case "$cmd" in
+            init) initialize ;;
+            tools) list_tools ;;
+            plan) start_planning "$args" ;;
+            save) save_plan "$args" ;;
+            todo) add_todo "$args" ;;
+            list) get_todos ;;
+            done) update_todo_status "$args" "completed" ;;
+            demo) demo ;;
+            quit|exit) break ;;
+            *) echo "Unknown command: $cmd" ;;
+        esac
+        echo ""
+    done
+}
+
+# Main
+main() {
+    POD=$(get_pod)
+    if [ -z "$POD" ]; then
+        echo -e "${RED}❌ No pod found with label $APP_LABEL in namespace $NAMESPACE${NC}"
+        exit 1
+    fi
+
+    if [ "$1" == "demo" ]; then
+        demo
+    elif [ "$1" == "interactive" ]; then
+        interactive
+    else
+        echo "Usage: $0 [demo|interactive]"
+        echo ""
+        echo "  demo         - Run a demo scenario"
+        echo "  interactive  - Start interactive mode"
+        echo ""
+        echo "Environment variables:"
+        echo "  K8S_NAMESPACE - Kubernetes namespace (default: devops)"
+        echo "  USER_ID       - User ID for session (default: demo-user)"
+        echo "  SESSION_ID    - Session ID (default: demo-session)"
+    fi
+}
+
+main "$@"

--- a/scripts/k8s-quick-test.sh
+++ b/scripts/k8s-quick-test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Quick test script for K8s MCP deployment
+# Performs basic smoke tests without complex session testing
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Configuration
+NAMESPACE="${K8S_NAMESPACE:-devops}"
+APP_LABEL="${APP_LABEL:-app=mcp-software-planning}"
+
+echo "🚀 Quick K8s MCP Test"
+echo "===================="
+
+# Get pod name
+POD=$(kubectl get pods -n "$NAMESPACE" -l "$APP_LABEL" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+if [ -z "$POD" ]; then
+    echo -e "${RED}❌ No pod found${NC}"
+    exit 1
+fi
+
+echo "Pod: $POD"
+echo ""
+
+# Test 1: Health check
+echo -n "1. Health check: "
+if kubectl exec -n "$NAMESPACE" "$POD" -- wget -qO- http://localhost:4626/health 2>/dev/null | grep -q "ok"; then
+    echo -e "${GREEN}✅ PASS${NC}"
+else
+    echo -e "${RED}❌ FAIL${NC}"
+fi
+
+# Test 2: Supergateway running
+echo -n "2. Supergateway: "
+if kubectl exec -n "$NAMESPACE" "$POD" -- pgrep -f supergateway >/dev/null 2>&1; then
+    echo -e "${GREEN}✅ Running${NC}"
+else
+    echo -e "${RED}❌ Not running${NC}"
+fi
+
+# Test 3: Redis connectivity
+echo -n "3. Redis connection: "
+REDIS_HOST=$(kubectl exec -n "$NAMESPACE" "$POD" -- sh -c 'echo ${REDIS_URL#redis://}' 2>/dev/null)
+if [ -n "$REDIS_HOST" ]; then
+    echo -e "${GREEN}✅ Configured${NC} ($REDIS_HOST)"
+else
+    echo -e "${RED}❌ Not configured${NC}"
+fi
+
+# Test 4: MCP server basic test
+echo -n "4. MCP server: "
+RESPONSE=$(kubectl exec -n "$NAMESPACE" "$POD" -- sh -c 'echo '\''{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"clientInfo":{"name":"quick-test","version":"1.0"}},"id":1}'\'' | timeout 5 node /app/build/index.js 2>&1' || echo "FAILED")
+
+if echo "$RESPONSE" | grep -q '"name":"software-planning-tool"'; then
+    echo -e "${GREEN}✅ Responding${NC}"
+elif echo "$RESPONSE" | grep -q "Redis connection established"; then
+    echo -e "${GREEN}✅ Running (with Redis)${NC}"
+else
+    echo -e "${RED}❌ Failed${NC}"
+    echo "Response: $RESPONSE"
+fi
+
+# Test 5: External access
+echo -n "5. External access: "
+if curl -s --max-time 3 https://planning-lab.erauner.dev/health 2>/dev/null | grep -q "ok"; then
+    echo -e "${GREEN}✅ Available${NC}"
+else
+    echo -e "${RED}⚠️  Not reachable${NC} (may be network issue)"
+fi
+
+echo ""
+echo "Quick test complete!"

--- a/scripts/k8s-smoke-test.sh
+++ b/scripts/k8s-smoke-test.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# K8s smoke test script to run inside the pod
+
+echo "🏥 MCP Server Smoke Test"
+echo "========================"
+
+# Test 1: Health check
+echo ""
+echo "1. Health Check:"
+wget -qO- http://localhost:4626/health && echo "✅ Health endpoint OK" || echo "❌ Health check failed"
+
+# Test 2: Direct stdio test (tools/list)
+echo ""
+echo "2. Testing tools/list via stdio:"
+echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | node /app/build/index.js | grep -q '"result"' && echo "✅ Tools list OK" || echo "❌ Tools list failed"
+
+# Test 3: Create goal
+echo ""
+echo "3. Testing create_goal:"
+echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_goal","arguments":{"description":"Smoke test goal","userId":"smoke-test","sessionId":"test-session"}},"id":2}' | node /app/build/index.js | grep -q '"result"' && echo "✅ Goal created" || echo "❌ Goal creation failed"
+
+# Test 4: Get current goal
+echo ""
+echo "4. Testing get_current_goal:"
+echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_current_goal","arguments":{"userId":"smoke-test","sessionId":"test-session"}},"id":3}' | node /app/build/index.js | grep -q 'Smoke test goal' && echo "✅ Goal retrieved" || echo "❌ Goal retrieval failed"
+
+# Test 5: Add todo
+echo ""
+echo "5. Testing add_todo:"
+echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"add_todo","arguments":{"description":"Test todo item","userId":"smoke-test","sessionId":"test-session"}},"id":4}' | node /app/build/index.js | grep -q '"result"' && echo "✅ Todo added" || echo "❌ Todo addition failed"
+
+# Test 6: List todos
+echo ""
+echo "6. Testing list_todos:"
+echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_todos","arguments":{"userId":"smoke-test","sessionId":"test-session"}},"id":5}' | node /app/build/index.js | grep -q 'Test todo item' && echo "✅ Todos listed" || echo "❌ Todo listing failed"
+
+# Test 7: Complete todo
+echo ""
+echo "7. Testing complete_todo:"
+echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"complete_todo","arguments":{"index":0,"userId":"smoke-test","sessionId":"test-session"}},"id":6}' | node /app/build/index.js | grep -q '"result"' && echo "✅ Todo completed" || echo "❌ Todo completion failed"
+
+# Test 8: Redis connection
+echo ""
+echo "8. Testing Redis connection:"
+echo "PING" | nc -w 1 snapdragon.devops.svc.cluster.local 6379 | grep -q "PONG" && echo "✅ Redis connected" || echo "❌ Redis connection failed"
+
+# Test 9: Session isolation
+echo ""
+echo "9. Testing session isolation:"
+# Create goal for user1
+echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_goal","arguments":{"description":"User1 goal","userId":"user1","sessionId":"session1"}},"id":10}' | node /app/build/index.js > /dev/null
+# Try to access user1's goal with user2
+RESULT=$(echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_current_goal","arguments":{"userId":"user2","sessionId":"session1"}},"id":11}' | node /app/build/index.js)
+if echo "$RESULT" | grep -q "User1 goal"; then
+  echo "❌ Session isolation FAILED - user2 accessed user1's data!"
+else
+  echo "✅ Session isolation working"
+fi
+
+echo ""
+echo "========================"
+echo "🎉 Smoke test complete!"

--- a/scripts/k8s-test.sh
+++ b/scripts/k8s-test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# K8s deployment testing script for Software Planning MCP Server
+# This script tests the MCP server deployed in Kubernetes
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+NAMESPACE="${K8S_NAMESPACE:-devops}"
+APP_LABEL="${APP_LABEL:-app=mcp-software-planning}"
+HEALTH_ENDPOINT="${HEALTH_ENDPOINT:-/health}"
+MCP_ENDPOINT="${MCP_ENDPOINT:-/mcp/stream}"
+
+# Helper functions
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+check_deployment() {
+    log_info "Checking deployment status..."
+
+    if ! kubectl get deployment -n "$NAMESPACE" -l "$APP_LABEL" &>/dev/null; then
+        log_error "No deployment found with label $APP_LABEL in namespace $NAMESPACE"
+        exit 1
+    fi
+
+    kubectl get deployment,pods,svc -n "$NAMESPACE" -l "$APP_LABEL"
+}
+
+get_pod_name() {
+    kubectl get pods -n "$NAMESPACE" -l "$APP_LABEL" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+test_health() {
+    log_info "Testing health endpoint..."
+
+    POD=$(get_pod_name)
+    if [ -z "$POD" ]; then
+        log_error "No pod found"
+        exit 1
+    fi
+
+    if kubectl exec -n "$NAMESPACE" "$POD" -- wget -qO- "http://localhost:4626${HEALTH_ENDPOINT}" | grep -q "ok"; then
+        log_info "✅ Health check passed"
+    else
+        log_error "❌ Health check failed"
+        return 1
+    fi
+}
+
+test_stdio_direct() {
+    log_info "Testing MCP server directly via stdio..."
+
+    POD=$(get_pod_name)
+    if [ -z "$POD" ]; then
+        log_error "No pod found"
+        exit 1
+    fi
+
+    # Test initialize
+    local response=$(kubectl exec -n "$NAMESPACE" "$POD" -- sh -c 'echo '\''{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'\'' | timeout 5 node /app/build/index.js 2>/dev/null' || echo "TIMEOUT")
+
+    if [[ "$response" == "TIMEOUT" ]]; then
+        log_error "❌ MCP server timed out"
+        return 1
+    elif echo "$response" | grep -q '"name":"software-planning-tool"'; then
+        log_info "✅ MCP server initialized successfully"
+    else
+        log_error "❌ MCP server failed to initialize"
+        echo "Response: $response"
+        return 1
+    fi
+}
+
+test_redis_connection() {
+    log_info "Testing Redis connection..."
+
+    POD=$(get_pod_name)
+    if [ -z "$POD" ]; then
+        log_error "No pod found"
+        exit 1
+    fi
+
+    # Check Redis environment variables
+    kubectl exec -n "$NAMESPACE" "$POD" -- env | grep -E "REDIS|STORAGE" || true
+
+    # Test Redis connectivity
+    if kubectl exec -n "$NAMESPACE" "$POD" -- sh -c 'echo "PING" | nc -w 1 ${REDIS_URL#redis://} 2>/dev/null | grep -q "PONG"' 2>/dev/null; then
+        log_info "✅ Redis connection successful"
+    else
+        log_warning "⚠️  Redis connection test inconclusive (nc might not be available)"
+    fi
+}
+
+test_supergateway() {
+    log_info "Checking supergateway status..."
+
+    POD=$(get_pod_name)
+    if [ -z "$POD" ]; then
+        log_error "No pod found"
+        exit 1
+    fi
+
+    # Check if supergateway is running
+    if kubectl exec -n "$NAMESPACE" "$POD" -- ps aux | grep -q "[s]upergateway"; then
+        log_info "✅ Supergateway is running"
+
+        # Show supergateway configuration
+        kubectl logs -n "$NAMESPACE" "$POD" --tail=20 | grep -E "supergateway|Listening" || true
+    else
+        log_error "❌ Supergateway is not running"
+        return 1
+    fi
+}
+
+show_logs() {
+    log_info "Recent pod logs:"
+    POD=$(get_pod_name)
+    if [ -n "$POD" ]; then
+        kubectl logs -n "$NAMESPACE" "$POD" --tail=30
+    fi
+}
+
+# Main execution
+main() {
+    echo "🧪 MCP Software Planning K8s Test Suite"
+    echo "======================================="
+    echo "Namespace: $NAMESPACE"
+    echo "App Label: $APP_LABEL"
+    echo ""
+
+    check_deployment
+    echo ""
+
+    test_health
+    echo ""
+
+    test_supergateway
+    echo ""
+
+    test_redis_connection
+    echo ""
+
+    test_stdio_direct
+    echo ""
+
+    if [ "${SHOW_LOGS:-false}" == "true" ]; then
+        show_logs
+    fi
+
+    log_info "✅ All tests completed!"
+}
+
+# Run main function
+main "$@"

--- a/scripts/k8s-tools-test.sh
+++ b/scripts/k8s-tools-test.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# Test MCP tools functionality in K8s deployment
+# This script tests each MCP tool by calling it directly via stdio
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+NAMESPACE="${K8S_NAMESPACE:-devops}"
+APP_LABEL="${APP_LABEL:-app=mcp-software-planning}"
+TEST_USER="${TEST_USER:-k8s-test-user}"
+TEST_SESSION="${TEST_SESSION:-k8s-test-session}"
+
+# Helper functions
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_test() {
+    echo -e "${BLUE}[TEST]${NC} $1"
+}
+
+get_pod_name() {
+    kubectl get pods -n "$NAMESPACE" -l "$APP_LABEL" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# Execute MCP request via stdio
+exec_mcp_request() {
+    local request="$1"
+    local pod=$(get_pod_name)
+
+    if [ -z "$pod" ]; then
+        log_error "No pod found"
+        return 1
+    fi
+
+    # Use timeout with TERM signal and shorter timeout
+    kubectl exec -n "$NAMESPACE" "$pod" -- sh -c "echo '$request' | timeout -s TERM 5 node /app/build/index.js 2>&1" 2>/dev/null || echo '{"error": "timeout"}'
+}
+
+# Test functions for each tool
+test_initialize() {
+    log_test "Testing initialize..."
+
+    local request='{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"clientInfo":{"name":"k8s-test","version":"1.0"}},"id":1}'
+    local response=$(exec_mcp_request "$request")
+
+    if echo "$response" | grep -q '"name":"software-planning-tool"'; then
+        log_info "✅ Initialize successful"
+        return 0
+    else
+        log_error "❌ Initialize failed"
+        echo "$response"
+        return 1
+    fi
+}
+
+test_tools_list() {
+    log_test "Testing tools/list..."
+
+    local request='{"jsonrpc":"2.0","method":"tools/list","id":2}'
+    local response=$(exec_mcp_request "$request")
+
+    if echo "$response" | grep -q '"tools"'; then
+        local tool_count=$(echo "$response" | grep -o '"name"' | wc -l)
+        log_info "✅ Found $tool_count tools"
+
+        # List tool names
+        echo "$response" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//' | while read -r tool; do
+            echo "   - $tool"
+        done
+        return 0
+    else
+        log_error "❌ Tools list failed"
+        echo "$response"
+        return 1
+    fi
+}
+
+test_start_planning() {
+    log_test "Testing start_planning..."
+
+    local request='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"start_planning","arguments":{"task":"Test planning from K8s","userId":"'$TEST_USER'","sessionId":"'$TEST_SESSION'"}},"id":3}'
+    local response=$(exec_mcp_request "$request")
+
+    if echo "$response" | grep -q '"result"'; then
+        log_info "✅ Planning started successfully"
+        return 0
+    else
+        log_error "❌ Start planning failed"
+        echo "$response"
+        return 1
+    fi
+}
+
+test_save_plan() {
+    log_test "Testing save_plan..."
+
+    local request='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"save_plan","arguments":{"plan":"Test plan content","userId":"'$TEST_USER'","sessionId":"'$TEST_SESSION'"}},"id":4}'
+    local response=$(exec_mcp_request "$request")
+
+    if echo "$response" | grep -q '"result"'; then
+        log_info "✅ Plan saved successfully"
+        return 0
+    else
+        log_error "❌ Save plan failed"
+        echo "$response"
+        return 1
+    fi
+}
+
+test_add_todo() {
+    log_test "Testing add_todo..."
+
+    local request='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"add_todo","arguments":{"description":"Test todo item","userId":"'$TEST_USER'","sessionId":"'$TEST_SESSION'"}},"id":5}'
+    local response=$(exec_mcp_request "$request")
+
+    if echo "$response" | grep -q '"result"'; then
+        log_info "✅ Todo added successfully"
+        return 0
+    else
+        log_error "❌ Add todo failed"
+        echo "$response"
+        return 1
+    fi
+}
+
+test_get_todos() {
+    log_test "Testing get_todos..."
+
+    local request='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_todos","arguments":{"userId":"'$TEST_USER'","sessionId":"'$TEST_SESSION'"}},"id":6}'
+    local response=$(exec_mcp_request "$request")
+
+    if echo "$response" | grep -q 'Test todo item'; then
+        log_info "✅ Listed todos successfully"
+        return 0
+    else
+        log_error "❌ Get todos failed"
+        echo "$response"
+        return 1
+    fi
+}
+
+test_session_isolation() {
+    log_test "Testing session isolation..."
+
+    # Start planning for user1
+    local request1='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"start_planning","arguments":{"task":"User1 private task","userId":"user1","sessionId":"session1"}},"id":10}'
+    exec_mcp_request "$request1" >/dev/null 2>&1
+
+    # Start planning for user2
+    local request2='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"start_planning","arguments":{"task":"User2 private task","userId":"user2","sessionId":"session2"}},"id":11}'
+    exec_mcp_request "$request2" >/dev/null 2>&1
+
+    # Add todos for each user
+    local request3='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"add_todo","arguments":{"description":"User1 todo","userId":"user1","sessionId":"session1"}},"id":12}'
+    exec_mcp_request "$request3" >/dev/null 2>&1
+
+    local request4='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"add_todo","arguments":{"description":"User2 todo","userId":"user2","sessionId":"session2"}},"id":13}'
+    exec_mcp_request "$request4" >/dev/null 2>&1
+
+    # Try to access user2's todos with user1
+    local request5='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_todos","arguments":{"userId":"user1","sessionId":"session2"}},"id":14}'
+    local response=$(exec_mcp_request "$request5")
+
+    if echo "$response" | grep -q "User2 todo"; then
+        log_error "❌ Session isolation FAILED - user1 accessed user2's data!"
+        return 1
+    else
+        log_info "✅ Session isolation working correctly"
+        return 0
+    fi
+}
+
+cleanup_test_data() {
+    log_test "Cleaning up test data..."
+
+    # Note: There's no explicit clear method in the new API
+    # Data will be cleaned up by Redis TTL
+
+    log_info "✅ Test data will be cleaned up by Redis TTL"
+}
+
+# Main execution
+main() {
+    echo "🛠️  MCP Tools Test Suite for K8s"
+    echo "================================"
+    echo "Namespace: $NAMESPACE"
+    echo "Test User: $TEST_USER"
+    echo "Test Session: $TEST_SESSION"
+    echo ""
+
+    # Check if pod exists
+    POD=$(get_pod_name)
+    if [ -z "$POD" ]; then
+        log_error "No pod found with label $APP_LABEL in namespace $NAMESPACE"
+        exit 1
+    fi
+
+    log_info "Testing pod: $POD"
+    echo ""
+
+    # Run tests
+    test_initialize || exit 1
+    echo ""
+
+    test_tools_list || exit 1
+    echo ""
+
+    test_start_planning || exit 1
+    echo ""
+
+    test_save_plan || exit 1
+    echo ""
+
+    test_add_todo || exit 1
+    echo ""
+
+    test_get_todos || exit 1
+    echo ""
+
+    test_session_isolation || exit 1
+    echo ""
+
+    cleanup_test_data
+    echo ""
+
+    log_info "🎉 All tool tests passed!"
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
This PR adds Harbor registry support for building and publishing container images. Changes include:

- Updated Makefile to support both GHCR and Harbor registries  
- Added GitHub Actions workflow for automated Harbor publishing
- Added Taskfile convenience commands for local Harbor operations
- Configured proper image tagging and authentication for Harbor

This enables the move from GHCR to self-hosted Harbor registry for better control and security.

**Testing:**
- Build process works with both registries  
- GitHub Actions workflow configured for Harbor
- Local development supports both registries via make targets

**Dependencies:**
- Requires Harbor registry deployment in homelab-k8s
- Requires GitHub secrets setup for Harbor authentication